### PR TITLE
chore: let users handle container termination

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+linters:
+  enable:
+    - errorlint
+    - gci
+    - gocritic
+    - gofumpt
+    - misspell
+    - nonamedreturns
+    - testifylint
+    - errcheck
+
+linters-settings:
+  errorlint:
+    # Check whether fmt.Errorf uses the %w verb for formatting errors.
+    # See the https://github.com/polyfloyd/go-errorlint for caveats.
+    errorf: true
+    # Permit more than 1 %w verb, valid per Go 1.20 (Requires errorf:true)
+    errorf-multi: true
+    # Check for plain type assertions and type switches.
+    asserts: true
+    # Check for plain error comparisons.
+    comparison: true
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/testcontainers)
+  testifylint:
+    disable:
+      - float-compare
+      - go-require
+    enable:
+      - bool-compare
+      - compares
+      - empty
+      - error-is-as
+      - error-nil
+      - expected-actual
+      - len
+      - require-error
+      - suite-dont-use-pkg
+      - suite-extra-assert-call
+run:
+  timeout: 5m

--- a/examples_test.go
+++ b/examples_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	spicedb "github.com/mariscal6/testcontainers-spicedb-go"
+
 	"github.com/testcontainers/testcontainers-go"
 )
 

--- a/spicedb.go
+++ b/spicedb.go
@@ -79,12 +79,16 @@ func RunContainer(ctx context.Context, opts ...testcontainers.ContainerCustomize
 		return nil, err
 	}
 
+	c := &spiceDBContainer{Container: container, secretKey: cfg.SecretKey, model: cfg.Model}
+
 	endpoint, err := container.Endpoint(ctx, "")
 	if err != nil {
-		container.Terminate(ctx)
-		return nil, err
+		return c, err
 	}
-	return &spiceDBContainer{Container: container, secretKey: cfg.SecretKey, endpoint: endpoint, model: cfg.Model}, nil
+
+	c.endpoint = endpoint
+
+	return c, nil
 }
 
 func WithOtel(otelProvider string, enpoint string) testcontainers.CustomizeRequestOption {

--- a/spicedb.go
+++ b/spicedb.go
@@ -8,10 +8,11 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
 	"github.com/authzed/grpcutil"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 const (

--- a/spicedb_test.go
+++ b/spicedb_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/authzed/grpcutil"
 	spicedbcontainer "github.com/mariscal6/testcontainers-spicedb-go"
 	"github.com/mariscal6/testcontainers-spicedb-go/testdata"
-	"github.com/testcontainers/testcontainers-go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/testcontainers/testcontainers-go"
 )
 
 func TestSpiceDB(t *testing.T) {
@@ -20,7 +21,6 @@ func TestSpiceDB(t *testing.T) {
 	container, err := spicedbcontainer.RunContainer(ctx,
 		testcontainers.WithImage("authzed/spicedb:v1.33.0"),
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,6 @@ func TestSpiceDB(t *testing.T) {
 		grpcutil.WithInsecureBearerToken(container.SecretKey()),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +63,6 @@ func TestSpiceDBSecretCustomizer(t *testing.T) {
 		testcontainers.WithImage("authzed/spicedb:v1.33.0"),
 		customizer,
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +79,6 @@ func TestSpiceDBSecretCustomizer(t *testing.T) {
 		grpcutil.WithInsecureBearerToken(secretKey),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +106,6 @@ func TestSpiceModelCustomizer(t *testing.T) {
 		testcontainers.WithImage("authzed/spicedb:v1.33.0"),
 		modelCustomizer,
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +122,6 @@ func TestSpiceModelCustomizer(t *testing.T) {
 		grpcutil.WithInsecureBearerToken(defaultSecretKey),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
-
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- **chore: add golangci-lint descriptor**
- **chore: lint**
- **chore: do not terminate container on error**

## What does this PR do?
It does not terminate the container if the endpoint cannot be obtained.

It also adds the golangci-lint configuration

## Why is it important?
It lets user react in the way they prefer.
