### PR TITLE
Make Run() use the image passed by user

### DIFF
--- a/spicedb.go
+++ b/spicedb.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, image string, opts ...testcontainers.ContainerCust
 		SecretKey: defaultSecretKey,
 	}
 	req := testcontainers.ContainerRequest{
-		Image:        "authzed/spicedb:v1.33.0",
+		Image:        image,
 		ExposedPorts: []string{"50051/tcp"},
 		Cmd:          []string{"serve", "--grpc-preshared-key", defaultSecretKey},
 		WaitingFor: wait.ForAll(


### PR DESCRIPTION
I've noticed a bug in `Run(ctx context.Context, image string, ...)`, it doesn't actually use the `image` passed in by the user at all, instead it just hardcodes it to `"authzed/spicedb:v1.33.0"`.

@Mariscal6 would appreciate it a lot if this could be resolved and afterwards released as a new version, thank you!